### PR TITLE
added cloudship airframe, mixer, manual flying

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -20,8 +20,8 @@
 	branch = master
 [submodule "Tools/sitl_gazebo"]
 	path = Tools/sitl_gazebo
-	url = https://github.com/PX4/sitl_gazebo.git
-	branch = master
+	url = https://github.com/flycloudline/sitl_gazebo_airship.git
+	branch = cloudline
 [submodule "src/lib/matrix"]
 	path = src/lib/matrix
 	url = https://github.com/PX4/Matrix.git

--- a/ROMFS/px4fmu_common/init.d-posix/2507_cloudship
+++ b/ROMFS/px4fmu_common/init.d-posix/2507_cloudship
@@ -1,0 +1,42 @@
+#!/bin/sh
+#
+# @name Cloudship
+# @type Airship
+# @class Airship
+#
+# @output MAIN1 stabilator
+# @output MAIN2 motor 1 starboard
+# @output MAIN3 motor 2 port
+# @output MAIN4 rudder motor
+
+sh /etc/init.d/rc.lta_defaults
+
+param set PWM_MAX 2000
+param set PWM_MIN 1000
+
+param set MPC_MANTHR_MIN 0.00
+param set MPC_THR_MIN 0.00
+param set MPC_THR_CURVE 1
+param set MPC_THR_HOVER 0.0
+
+param set NAV_DLL_ACT 0
+param set NAV_RCL_ACT 0
+
+param set LT_YAW_P 1.0
+param set LT_YAWRATE_P 0.4
+param set LT_YAWRATE_I 0.2
+param set LT_YAWRATE_D 0.05
+param set LT_YAWRATE_FF 0.0
+param set LT_YAWRATE_MAX 360.0
+param set MC_ACRO_Y_MAX 360.0
+param set MPC_MAN_Y_MAX 360.0
+
+param set LNDMC_Z_VEL_MAX 0.01
+param set LNDMC_XY_VEL_MAX 0.01
+param set LNDMC_LOW_T_THR 0.01
+param set LNDMC_ROT_MAX 1.0
+
+set MIXER cloudship
+
+# Configure this as airship.
+# set MAV_TYPE 7

--- a/ROMFS/px4fmu_common/init.d/airframes/2507_cloudship
+++ b/ROMFS/px4fmu_common/init.d/airframes/2507_cloudship
@@ -1,0 +1,44 @@
+#!/bin/sh
+#
+# @name Cloudship
+# @type Airship
+# @class Airship
+#
+# @output MAIN1 stabilator
+# @output MAIN2 motor 1 starboard
+# @output MAIN3 motor 2 port
+# @output MAIN4 rudder motor
+
+sh /etc/init.d/rc.lta_defaults
+
+param set PWM_MAX 2000
+param set PWM_MIN 1000
+
+param set MPC_MANTHR_MIN 0.00
+param set MPC_THR_MIN 0.00
+param set MPC_THR_CURVE 1
+param set MPC_THR_HOVER 0.0
+
+param set NAV_DLL_ACT 0
+param set NAV_RCL_ACT 0
+
+param set LT_YAW_P 1.0
+param set LT_YAWRATE_P 0.4
+param set LT_YAWRATE_I 0.2
+param set LT_YAWRATE_D 0.05
+param set LT_YAWRATE_FF 0.0
+param set LT_YAWRATE_MAX 360.0
+param set MC_ACRO_Y_MAX 360.0
+param set MPC_MAN_Y_MAX 360.0
+
+param set LNDMC_Z_VEL_MAX 0.01
+param set LNDMC_XY_VEL_MAX 0.01
+param set LNDMC_LOW_T_THR 0.01
+param set LNDMC_ROT_MAX 1.0
+
+set MIXER cloudship
+
+# Configure this as airship.
+# set MAV_TYPE 7
+
+set PWM_OUT 1234

--- a/ROMFS/px4fmu_common/init.d/rc.lta_apps
+++ b/ROMFS/px4fmu_common/init.d/rc.lta_apps
@@ -1,0 +1,65 @@
+#!/bin/sh
+#
+# Standard apps for airships. Attitude/Position estimator, Attitude/Position control.
+#
+# NOTE: Script variables are declared/initialized/unset in the rcS script.
+#
+
+###############################################################################
+#                       Begin Estimator Group Selection                       #
+###############################################################################
+
+#
+# LPE
+#
+if param compare SYS_MC_EST_GROUP 1
+then
+	#
+	# Try to start LPE. If it fails, start EKF2 as a default.
+	# Unfortunately we do not build it on px4_fmu-v2 due to a limited flash.
+	#
+	if attitude_estimator_q start
+	then
+		echo "WARN [init] Estimator LPE unsupported, EKF2 recommended."
+		local_position_estimator start
+	else
+		echo "ERROR [init] Estimator LPE not available. Using EKF2"
+		param set SYS_MC_EST_GROUP 2
+		param save
+		reboot
+	fi
+else
+	#
+	# Q estimator (attitude estimation only)
+	#
+	if param compare SYS_MC_EST_GROUP 3
+	then
+		attitude_estimator_q start
+	else
+		#
+		# EKF2
+		#
+		param set SYS_MC_EST_GROUP 2
+		ekf2 start
+	fi
+fi
+
+###############################################################################
+#                        End Estimator Group Selection                        #
+###############################################################################
+
+#
+# Start Airship Attitude Controller.
+#
+lta_att_control start
+
+#
+# Start Position Controller.
+#
+mc_pos_control start
+
+#
+# Start Land Detector.
+#
+land_detector start multicopter
+

--- a/ROMFS/px4fmu_common/init.d/rc.lta_defaults
+++ b/ROMFS/px4fmu_common/init.d/rc.lta_defaults
@@ -1,0 +1,28 @@
+#!/bin/sh
+#
+# Airship default parameters.
+#
+# NOTE: Script variables are declared/initialized/unset in the rcS script.
+#
+
+set VEHICLE_TYPE lta
+
+if [ $AUTOCNF = yes ]
+then
+	param set NAV_ACC_RAD 2
+
+	param set RTL_RETURN_ALT 30
+	param set RTL_DESCEND_ALT 10
+	param set RTL_LAND_DELAY 1
+
+	param set PWM_MAX 2000
+	param set PWM_MIN 1000
+	param set PWM_RATE 400
+fi
+
+#
+# This is the gimbal pass mixer.
+#
+set MIXER_AUX pass
+
+set PWM_AUX_OUT 1234

--- a/ROMFS/px4fmu_common/init.d/rc.vehicle_setup
+++ b/ROMFS/px4fmu_common/init.d/rc.vehicle_setup
@@ -85,6 +85,32 @@ then
 fi
 
 #
+# Airship setup.
+#
+if [ $VEHICLE_TYPE = lta ]
+then
+	if [ $MIXER = none ]
+	then
+		echo "LTA mixer undefined"
+	fi
+
+	if [ $MAV_TYPE = none ]
+	then
+		# Set a default MAV_TYPE = 2 if not defined.
+		set MAV_TYPE 2
+	fi
+
+	# Set the mav type parameter.
+	param set MAV_TYPE ${MAV_TYPE}
+
+	# Load mixer and configure outputs.
+	sh /etc/init.d/rc.interface
+
+	# Start standard airship apps.
+	sh /etc/init.d/rc.lta_apps
+fi
+
+#
 # UGV setup.
 #
 if [ $VEHICLE_TYPE = rover ]

--- a/ROMFS/px4fmu_common/mixers/cloudship.main.mix
+++ b/ROMFS/px4fmu_common/mixers/cloudship.main.mix
@@ -1,0 +1,52 @@
+Stabilator/thruster/rudder mixer for PX4FMU
+=======================================================
+
+This file defines mixers suitable for controlling an airship with
+stabilator, rudder rotor, starboard and port thruster using PX4FMU.
+The configuration assumes the stabilator servo is connected to PX4FMU servo
+output 0, starboard thruster to output 1, port thruster to output 2, and the
+rudder rotor to output 3.
+
+Inputs to the mixer come from channel group 0 (vehicle attitude), channels 0
+(roll), 1 (pitch), 2 (yaw) and 3 (thrust) 4 (flaps).
+
+Servo controlling stabilator mixer
+------------
+Two scalers total (output, thrust angle).
+
+This mixer assumes that the stabilator servo is set up correctly mechanically;
+depending on the actual configuration it may be necessary to reverse the scaling
+factors (to reverse the servo movement) and adjust the offset, scaling and
+endpoints to suit.
+
+M: 1
+S: 0 1  10000  10000      0 -10000  10000
+
+Starboard and port thruster mixer
+-----------------
+Two scalers total (output, thrust).
+
+By default mixer output is normalized. In the case of certain input controllers
+the commented lines generate a full-range output (-1 to 1) from an input in the
+(0 - 1) range. Inputs below zero are treated as zero.
+
+M: 1
+S: 0 3  20000  20000       -10000 -10000  10000
+#S: 0 3  10000  10000           0 -10000  10000
+
+M: 1
+S: 0 3  20000  20000       -10000 -10000  10000
+#S: 0 3  10000  10000           0 -10000  10000
+
+Rudder rotor mixer
+------------
+Two scalers total (output, yaw).
+
+This mixer assumes that the rudder rotor is set up correctly mechanically;
+depending on the actual configuration it may be necessary to reverse the scaling
+factors (to reverse the motor movement) and adjust the offset, scaling and
+endpoints to suit.
+
+M: 1
+S: 0 2  10000  10000   0      -10000  10000
+

--- a/Tools/px4airframes/srcparser.py
+++ b/Tools/px4airframes/srcparser.py
@@ -88,6 +88,8 @@ class ParameterGroup(object):
             return "YMinus"
         elif (self.name == "Tricopter Y+"):
             return "YPlus"
+        elif (self.name == "Airship"):
+            return "Airship"
         elif (self.name == "Rover"):
             return "Rover"
         elif (self.name == "Boat"):

--- a/Tools/uorb_graph/create.py
+++ b/Tools/uorb_graph/create.py
@@ -247,6 +247,9 @@ class Graph(object):
     ('mc_att_control', r'mc_att_control_main\.cpp$', r'\b_actuators_id=([^,)]+)', r'^_actuators_id$'),
     ('mc_att_control', r'mc_att_control_main\.cpp$', r'\_attitude_sp_id=([^,)]+)', r'^_attitude_sp_id$'),
 
+    ('lta_att_control', r'lta_att_control_main\.cpp$', r'\b_actuators_id=([^,)]+)', r'^_actuators_id$'),
+    ('lta_att_control', r'lta_att_control_main\.cpp$', r'\_attitude_sp_id=([^,)]+)', r'^_attitude_sp_id$'),
+
     ('fw_att_control', r'FixedwingAttitudeControl\.cpp$', r'\b_actuators_id=([^,)]+)', r'^_actuators_id$'),
     ('fw_att_control', r'FixedwingAttitudeControl\.cpp$', r'\b_attitude_setpoint_id=([^,)]+)', r'^_attitude_setpoint_id$'),
 

--- a/boards/px4/sitl/airship.cmake
+++ b/boards/px4/sitl/airship.cmake
@@ -1,0 +1,104 @@
+
+px4_add_board(
+	PLATFORM posix
+	VENDOR px4
+	MODEL sitl
+	LABEL airship
+	TESTING
+
+	DRIVERS
+		#barometer # all available barometer drivers
+		#batt_smbus
+		camera_trigger
+		#differential_pressure # all available differential pressure drivers
+		#distance_sensor # all available distance sensor drivers
+		gps
+		#imu # all available imu drivers
+		#magnetometer # all available magnetometer drivers
+		pwm_out_sim
+		#telemetry # all available telemetry drivers
+		tone_alarm
+		#uavcan
+
+	MODULES
+		attitude_estimator_q
+		camera_feedback
+		commander
+		dataman
+		ekf2
+		events
+		fw_att_control
+		fw_pos_control_l1
+		rover_pos_control
+		land_detector
+		landing_target_estimator
+		load_mon
+		local_position_estimator
+		logger
+		lta_att_control
+		mavlink
+		#mc_att_control
+		mc_pos_control
+		navigator
+		replay
+		sensors
+		simulator
+		vmount
+		vtol_att_control
+		airspeed_selector
+
+	SYSTEMCMDS
+		#bl_update
+		#config
+		#dumpfile
+		dyn
+		esc_calib
+		#hardfault_log
+		led_control
+		mixer
+		motor_ramp
+		motor_test
+		#mtd
+		#nshterm
+		param
+		perf
+		pwm
+		reboot
+		sd_bench
+		shutdown
+		tests # tests and test runner
+		top
+		topic_listener
+		tune_control
+		ver
+		work_queue
+
+	EXAMPLES
+		bottle_drop # OBC challenge
+		dyn_hello # dynamically loading modules example
+		fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
+		hello
+		#hwtest # Hardware test
+		px4_mavlink_debug # Tutorial code from http://dev.px4.io/en/debug/debug_values.html
+		px4_simple_app # Tutorial code from http://dev.px4.io/en/apps/hello_sky.html
+		rover_steering_control # Rover example app
+	)
+
+set(config_sitl_viewer jmavsim CACHE STRING "viewer for sitl")
+set_property(CACHE config_sitl_viewer PROPERTY STRINGS "jmavsim;none")
+
+set(config_sitl_debugger disable CACHE STRING "debugger for sitl")
+set_property(CACHE config_sitl_debugger PROPERTY STRINGS "disable;gdb;lldb")
+
+# If the environment variable 'replay' is defined, we are building with replay
+# support. In this case, we enable the orb publisher rules.
+set(REPLAY_FILE "$ENV{replay}")
+if(REPLAY_FILE)
+	message(STATUS "Building with uorb publisher rules support")
+	add_definitions(-DORB_USE_PUBLISHER_RULES)
+
+	message(STATUS "Building without lockstep for replay")
+	set(ENABLE_LOCKSTEP_SCHEDULER no)
+else()
+	set(ENABLE_LOCKSTEP_SCHEDULER yes)
+endif()

--- a/msg/vehicle_status.msg
+++ b/msg/vehicle_status.msg
@@ -53,6 +53,7 @@ uint8 VEHICLE_TYPE_UNKNOWN = 0
 uint8 VEHICLE_TYPE_ROTARY_WING = 1
 uint8 VEHICLE_TYPE_FIXED_WING = 2
 uint8 VEHICLE_TYPE_ROVER = 3
+uint8 VEHICLE_TYPE_LTA = 4
 
 # state machine / state of vehicle.
 # Encodes the complete system state and is set by the commander app.

--- a/platforms/posix/cmake/sitl_target.cmake
+++ b/platforms/posix/cmake/sitl_target.cmake
@@ -52,6 +52,7 @@ set(models none shell
 	if750a iris iris_opt_flow iris_vision iris_rplidar iris_irlock iris_obs_avoid solo typhoon_h480
 	plane
 	standard_vtol tailsitter tiltrotor
+	cloudship
 	hippocampus rover)
 set(all_posix_vmd_make_targets)
 foreach(viewer ${viewers})

--- a/src/modules/lta_att_control/CMakeLists.txt
+++ b/src/modules/lta_att_control/CMakeLists.txt
@@ -1,0 +1,46 @@
+############################################################################
+#
+#   Copyright (c) 2015 PX4 Development Team. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name PX4 nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+############################################################################
+
+px4_add_module(
+	MODULE modules__lta_att_control
+	MAIN lta_att_control
+	STACK_MAX 3500
+	COMPILE_FLAGS
+	SRCS
+		lta_att_control_main.cpp
+	DEPENDS
+		circuit_breaker
+		conversion
+		mathlib
+		px4_work_queue
+	)

--- a/src/modules/lta_att_control/lta_att_control.hpp
+++ b/src/modules/lta_att_control/lta_att_control.hpp
@@ -1,0 +1,259 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2013-2018 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include <lib/mixer/mixer.h>
+#include <matrix/matrix/math.hpp>
+#include <perf/perf_counter.h>
+#include <px4_config.h>
+#include <px4_defines.h>
+#include <px4_module.h>
+#include <px4_module_params.h>
+#include <px4_posix.h>
+#include <px4_platform_common/px4_work_queue/WorkItem.hpp>
+#include <uORB/Publication.hpp>
+#include <uORB/PublicationMulti.hpp>
+#include <uORB/Subscription.hpp>
+#include <uORB/SubscriptionCallback.hpp>
+#include <uORB/topics/actuator_controls.h>
+#include <uORB/topics/battery_status.h>
+#include <uORB/topics/manual_control_setpoint.h>
+#include <uORB/topics/multirotor_motor_limits.h>
+#include <uORB/topics/parameter_update.h>
+#include <uORB/topics/rate_ctrl_status.h>
+#include <uORB/topics/vehicle_angular_velocity.h>
+#include <uORB/topics/vehicle_attitude.h>
+#include <uORB/topics/vehicle_attitude_setpoint.h>
+#include <uORB/topics/vehicle_control_mode.h>
+#include <uORB/topics/vehicle_rates_setpoint.h>
+#include <uORB/topics/vehicle_status.h>
+#include <uORB/topics/vehicle_land_detected.h>
+#include <uORB/topics/landing_gear.h>
+#include <vtol_att_control/vtol_type.h>
+
+/**
+ * Multicopter attitude control app start / stop handling function
+ */
+extern "C" __EXPORT int lta_att_control_main(int argc, char *argv[]);
+
+class LTAAttitudeControl : public ModuleBase<LTAAttitudeControl>, public ModuleParams,
+	public px4::WorkItem
+{
+public:
+	LTAAttitudeControl();
+
+	virtual ~LTAAttitudeControl();
+
+	/** @see ModuleBase */
+	static int task_spawn(int argc, char *argv[]);
+
+	/** @see ModuleBase */
+	static int custom_command(int argc, char *argv[]);
+
+	/** @see ModuleBase */
+	static int print_usage(const char *reason = nullptr);
+
+	/** @see ModuleBase::print_status() */
+	int print_status() override;
+
+	void Run() override;
+
+	bool init();
+
+private:
+
+	/**
+	 * initialize some vectors/matrices from parameters
+	 */
+	void		parameters_updated();
+
+	/**
+	 * Check for parameter update and handle it.
+	 */
+	void		parameter_update_poll();
+	bool		vehicle_attitude_poll();
+	void		vehicle_motor_limits_poll();
+	void		vehicle_status_poll();
+
+	void		publish_actuator_controls();
+	void		publish_rates_setpoint();
+	void		publish_rate_controller_status();
+
+	float		throttle_curve(float throttle_stick_input);
+
+	/**
+	 * Generate & publish an attitude setpoint from stick inputs
+	 */
+	void		generate_attitude_setpoint(float dt, bool reset_yaw_sp);
+
+	/**
+	 * Get the landing gear state based on the manual control switch position
+	 * @return vehicle_attitude_setpoint_s::LANDING_GEAR_UP or vehicle_attitude_setpoint_s::LANDING_GEAR_DOWN
+	 */
+	float		get_landing_gear_state();
+
+
+	/**
+	 * Attitude controller.
+	 */
+	void		control_attitude();
+
+	/**
+	 * Attitude rates controller.
+	 */
+	void		control_attitude_rates(float dt, const matrix::Vector3f &rates);
+
+	uORB::Subscription _v_att_sub{ORB_ID(vehicle_attitude)};			/**< vehicle attitude subscription */
+	uORB::Subscription _v_att_sp_sub{ORB_ID(vehicle_attitude_setpoint)};		/**< vehicle attitude setpoint subscription */
+	uORB::Subscription _v_rates_sp_sub{ORB_ID(vehicle_rates_setpoint)};		/**< vehicle rates setpoint subscription */
+	uORB::Subscription _v_control_mode_sub{ORB_ID(vehicle_control_mode)};		/**< vehicle control mode subscription */
+	uORB::Subscription _parameter_update_sub{ORB_ID(parameter_update)};		/**< parameter updates subscription */
+	uORB::Subscription _manual_control_sp_sub{ORB_ID(manual_control_setpoint)};	/**< manual control setpoint subscription */
+	uORB::Subscription _vehicle_status_sub{ORB_ID(vehicle_status)};			/**< vehicle status subscription */
+	uORB::Subscription _motor_limits_sub{ORB_ID(multirotor_motor_limits)};		/**< motor limits subscription */
+	uORB::Subscription _battery_status_sub{ORB_ID(battery_status)};			/**< battery status subscription */
+	uORB::Subscription _vehicle_land_detected_sub{ORB_ID(vehicle_land_detected)};	/**< vehicle land detected subscription */
+	uORB::Subscription _landing_gear_sub{ORB_ID(landing_gear)};
+
+	uORB::SubscriptionCallbackWorkItem _vehicle_angular_velocity_sub{this, ORB_ID(vehicle_angular_velocity)};
+
+	uORB::PublicationMulti<rate_ctrl_status_s>	_controller_status_pub{ORB_ID(rate_ctrl_status), ORB_PRIO_DEFAULT};	/**< controller status publication */
+	uORB::Publication<landing_gear_s>		_landing_gear_pub{ORB_ID(landing_gear)};
+	uORB::Publication<vehicle_rates_setpoint_s>	_v_rates_sp_pub{ORB_ID(vehicle_rates_setpoint)};			/**< rate setpoint publication */
+
+	orb_advert_t	_actuators_0_pub{nullptr};		/**< attitude actuator controls publication */
+	orb_advert_t	_vehicle_attitude_setpoint_pub{nullptr};
+
+	orb_id_t _actuators_id{nullptr};	/**< pointer to correct actuator controls0 uORB metadata structure */
+	orb_id_t _attitude_sp_id{nullptr};	/**< pointer to correct attitude setpoint uORB metadata structure */
+
+	bool		_actuators_0_circuit_breaker_enabled{false};	/**< circuit breaker to suppress output */
+
+	struct vehicle_attitude_s		_v_att {};		/**< vehicle attitude */
+	struct vehicle_attitude_setpoint_s	_v_att_sp {};		/**< vehicle attitude setpoint */
+	struct vehicle_rates_setpoint_s		_v_rates_sp {};		/**< vehicle rates setpoint */
+	struct manual_control_setpoint_s	_manual_control_sp {};	/**< manual control setpoint */
+	struct vehicle_control_mode_s		_v_control_mode {};	/**< vehicle control mode */
+	struct actuator_controls_s		_actuators {};		/**< actuator controls */
+	struct vehicle_status_s			_vehicle_status {};	/**< vehicle status */
+	struct battery_status_s			_battery_status {};	/**< battery status */
+	struct vehicle_land_detected_s		_vehicle_land_detected {};
+	struct landing_gear_s 			_landing_gear {};
+
+	MultirotorMixer::saturation_status _saturation_status{};
+
+	perf_counter_t	_loop_perf;			/**< loop performance counter */
+
+	static constexpr const float initial_update_rate_hz = 250.f; /**< loop update rate used for initialization */
+	float _loop_update_rate_hz{initial_update_rate_hz};          /**< current rate-controller loop update rate in [Hz] */
+
+	matrix::Vector3f _rates_sp;			/**< angular rates setpoint */
+
+	matrix::Vector3f _att_control;			/**< attitude control vector */
+	float		_thrust_sp{0.0f};		/**< thrust setpoint */
+
+	float _man_yaw_sp{0.f};				/**< current yaw setpoint in manual mode */
+	bool _gear_state_initialized{false};		/**< true if the gear state has been initialized */
+
+	hrt_abstime _task_start{hrt_absolute_time()};
+	hrt_abstime _last_run{0};
+	float _dt_accumulator{0.0f};
+	int _loop_counter{0};
+
+	bool _reset_yaw_sp{true};
+	float _attitude_dt{0.0f};
+
+	DEFINE_PARAMETERS(
+		(ParamFloat<px4::params::LT_ROLL_P>) _param_mc_roll_p,
+		(ParamFloat<px4::params::LT_ROLLRATE_P>) _param_mc_rollrate_p,
+		(ParamFloat<px4::params::LT_ROLLRATE_I>) _param_mc_rollrate_i,
+		(ParamFloat<px4::params::MC_RR_INT_LIM>) _param_mc_rr_int_lim,
+		(ParamFloat<px4::params::LT_ROLLRATE_D>) _param_mc_rollrate_d,
+		(ParamFloat<px4::params::LT_ROLLRATE_FF>) _param_mc_rollrate_ff,
+		(ParamFloat<px4::params::LT_ROLLRATE_K>) _param_mc_rollrate_k,
+
+		(ParamFloat<px4::params::LT_PITCH_P>) _param_mc_pitch_p,
+		(ParamFloat<px4::params::LT_PITCHRATE_P>) _param_mc_pitchrate_p,
+		(ParamFloat<px4::params::LT_PITCHRATE_I>) _param_mc_pitchrate_i,
+		(ParamFloat<px4::params::MC_PR_INT_LIM>) _param_mc_pr_int_lim,
+		(ParamFloat<px4::params::LT_PITCHRATE_D>) _param_mc_pitchrate_d,
+		(ParamFloat<px4::params::LT_PITCHRATE_FF>) _param_mc_pitchrate_ff,
+		(ParamFloat<px4::params::LT_PITCHRATE_K>) _param_mc_pitchrate_k,
+
+		(ParamFloat<px4::params::LT_YAW_P>) _param_mc_yaw_p,
+		(ParamFloat<px4::params::LT_YAWRATE_P>) _param_mc_yawrate_p,
+		(ParamFloat<px4::params::LT_YAWRATE_I>) _param_mc_yawrate_i,
+		(ParamFloat<px4::params::MC_YR_INT_LIM>) _param_mc_yr_int_lim,
+		(ParamFloat<px4::params::LT_YAWRATE_D>) _param_mc_yawrate_d,
+		(ParamFloat<px4::params::LT_YAWRATE_FF>) _param_mc_yawrate_ff,
+		(ParamFloat<px4::params::LT_YAWRATE_K>) _param_mc_yawrate_k,
+
+		(ParamFloat<px4::params::MC_DTERM_CUTOFF>) _param_mc_dterm_cutoff,			/**< Cutoff frequency for the D-term filter */
+
+		(ParamFloat<px4::params::LT_ROLLRATE_MAX>) _param_mc_rollrate_max,
+		(ParamFloat<px4::params::LT_PITCHRATE_MAX>) _param_mc_pitchrate_max,
+		(ParamFloat<px4::params::LT_YAWRATE_MAX>) _param_mc_yawrate_max,
+		(ParamFloat<px4::params::MPC_MAN_Y_MAX>) _param_mpc_man_y_max,			/**< scaling factor from stick to yaw rate */
+
+		(ParamFloat<px4::params::MC_ACRO_R_MAX>) _param_mc_acro_r_max,
+		(ParamFloat<px4::params::MC_ACRO_P_MAX>) _param_mc_acro_p_max,
+		(ParamFloat<px4::params::MC_ACRO_Y_MAX>) _param_mc_acro_y_max,
+		(ParamFloat<px4::params::MC_ACRO_EXPO>) _param_mc_acro_expo,				/**< expo stick curve shape (roll & pitch) */
+		(ParamFloat<px4::params::MC_ACRO_EXPO_Y>) _param_mc_acro_expo_y,				/**< expo stick curve shape (yaw) */
+		(ParamFloat<px4::params::MC_ACRO_SUPEXPO>) _param_mc_acro_supexpo,			/**< superexpo stick curve shape (roll & pitch) */
+		(ParamFloat<px4::params::MC_ACRO_SUPEXPOY>) _param_mc_acro_supexpoy,			/**< superexpo stick curve shape (yaw) */
+
+		(ParamFloat<px4::params::MC_RATT_TH>) _param_mc_ratt_th,
+
+		(ParamBool<px4::params::MC_BAT_SCALE_EN>) _param_mc_bat_scale_en,
+
+		/* Stabilized mode params */
+		(ParamFloat<px4::params::MPC_MAN_TILT_MAX>) _param_mpc_man_tilt_max,			/**< maximum tilt allowed for manual flight */
+		(ParamFloat<px4::params::MPC_MANTHR_MIN>) _param_mpc_manthr_min,			/**< minimum throttle for stabilized */
+		(ParamFloat<px4::params::MPC_THR_MAX>) _param_mpc_thr_max,				/**< maximum throttle for stabilized */
+		(ParamFloat<px4::params::MPC_THR_HOVER>)
+		_param_mpc_thr_hover,			/**< throttle at which vehicle is at hover equilibrium */
+		(ParamInt<px4::params::MPC_THR_CURVE>) _param_mpc_thr_curve,				/**< throttle curve behavior */
+
+		(ParamInt<px4::params::MC_AIRMODE>) _param_mc_airmode,
+
+		(ParamInt<px4::params::CBRK_RATE_CTRL>) _param_cbrk_rate_ctrl
+
+	)
+
+	bool _is_tailsitter{false};
+
+	matrix::Vector3f _acro_rate_max;	/**< max attitude rates in acro mode */
+	float _man_tilt_max;			/**< maximum tilt allowed for manual flight [rad] */
+
+};
+

--- a/src/modules/lta_att_control/lta_att_control_main.cpp
+++ b/src/modules/lta_att_control/lta_att_control_main.cpp
@@ -1,0 +1,444 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2013-2019 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file lta_att_control_main.cpp
+ * Multicopter attitude controller.
+ *
+ * @author Lorenz Meier		<lorenz@px4.io>
+ * @author Anton Babushkin	<anton.babushkin@me.com>
+ * @author Sander Smeets	<sander@droneslab.com>
+ * @author Matthias Grob	<maetugr@gmail.com>
+ * @author Beat Küng		<beat-kueng@gmx.net>
+ * @author Daniel Robinson  <daniel@flycloudline.com>
+ */
+
+#include "lta_att_control.hpp"
+
+#include <conversion/rotation.h>
+#include <drivers/drv_hrt.h>
+#include <lib/ecl/geo/geo.h>
+#include <circuit_breaker/circuit_breaker.h>
+#include <mathlib/math/Limits.hpp>
+#include <mathlib/math/Functions.hpp>
+
+using namespace matrix;
+
+LTAAttitudeControl::LTAAttitudeControl() :
+	ModuleParams(nullptr),
+	WorkItem(MODULE_NAME, px4::wq_configurations::rate_ctrl),
+	_loop_perf(perf_alloc(PC_ELAPSED, "lta_att_control"))
+{
+	_vehicle_status.vehicle_type = vehicle_status_s::VEHICLE_TYPE_ROTARY_WING;
+
+	/* initialize quaternions in messages to be valid */
+	_v_att.q[0] = 1.f;
+	_v_att_sp.q_d[0] = 1.f;
+
+	_rates_sp.zero();
+	_thrust_sp = 0.0f;
+	_att_control.zero();
+
+	parameters_updated();
+}
+
+LTAAttitudeControl::~LTAAttitudeControl()
+{
+	perf_free(_loop_perf);
+}
+
+bool
+LTAAttitudeControl::init()
+{
+	if (!_vehicle_angular_velocity_sub.registerCallback()) {
+		PX4_ERR("vehicle_angular_velocity callback registration failed!");
+		return false;
+	}
+
+	return true;
+}
+
+void
+LTAAttitudeControl::parameters_updated()
+{
+
+}
+
+void
+LTAAttitudeControl::parameter_update_poll()
+{
+	// check for parameter updates
+	if (_parameter_update_sub.updated()) {
+		// clear update
+		parameter_update_s pupdate;
+		_parameter_update_sub.copy(&pupdate);
+
+		// update parameters from storage
+		updateParams();
+	}
+}
+
+void
+LTAAttitudeControl::vehicle_status_poll()
+{
+	/* check if there is new status information */
+	if (_vehicle_status_sub.update(&_vehicle_status)) {
+		/* set correct uORB ID, depending on if vehicle is VTOL or not */
+		if (_actuators_id == nullptr) {
+			if (_vehicle_status.is_vtol) {
+				_actuators_id = ORB_ID(actuator_controls_virtual_mc);
+				_attitude_sp_id = ORB_ID(mc_virtual_attitude_setpoint);
+
+				int32_t vt_type = -1;
+
+				if (param_get(param_find("VT_TYPE"), &vt_type) == PX4_OK) {
+					_is_tailsitter = (static_cast<vtol_type>(vt_type) == vtol_type::TAILSITTER);
+				}
+
+			} else {
+				_actuators_id = ORB_ID(actuator_controls_0);
+				_attitude_sp_id = ORB_ID(vehicle_attitude_setpoint);
+			}
+		}
+	}
+}
+
+void
+LTAAttitudeControl::vehicle_motor_limits_poll()
+{
+	/* check if there is a new message */
+	multirotor_motor_limits_s motor_limits{};
+
+	if (_motor_limits_sub.update(&motor_limits)) {
+		_saturation_status.value = motor_limits.saturation_status;
+	}
+}
+
+bool
+LTAAttitudeControl::vehicle_attitude_poll()
+{
+	/* check if there is a new message */
+	const uint8_t prev_quat_reset_counter = _v_att.quat_reset_counter;
+
+	if (_v_att_sub.update(&_v_att)) {
+		// Check for a heading reset
+		if (prev_quat_reset_counter != _v_att.quat_reset_counter) {
+			// we only extract the heading change from the delta quaternion
+			_man_yaw_sp += Eulerf(Quatf(_v_att.delta_q_reset)).psi();
+		}
+		return true;
+	}
+	return false;
+}
+
+float
+LTAAttitudeControl::throttle_curve(float throttle_stick_input)
+{
+	float throttle_min = _vehicle_land_detected.landed ? 0.0f : _param_mpc_manthr_min.get();
+
+	// throttle_stick_input is in range [0, 1]
+	switch (_param_mpc_thr_curve.get()) {
+	case 1: // no rescaling to hover throttle
+		return throttle_min + throttle_stick_input * (_param_mpc_thr_max.get() - throttle_min);
+
+	default: // 0 or other: rescale to hover throttle at 0.5 stick
+		if (throttle_stick_input < 0.5f) {
+			return (_param_mpc_thr_hover.get() - throttle_min) / 0.5f * throttle_stick_input +
+			       throttle_min;
+
+		} else {
+			return (_param_mpc_thr_max.get() - _param_mpc_thr_hover.get()) / 0.5f * (throttle_stick_input - 1.0f) +
+			       _param_mpc_thr_max.get();
+		}
+	}
+}
+
+float
+LTAAttitudeControl::get_landing_gear_state()
+{
+	// Only switch the landing gear up if we are not landed and if
+	// the user switched from gear down to gear up.
+	// If the user had the switch in the gear up position and took off ignore it
+	// until he toggles the switch to avoid retracting the gear immediately on takeoff.
+	if (_vehicle_land_detected.landed) {
+		_gear_state_initialized = false;
+	}
+
+	float landing_gear = landing_gear_s::GEAR_DOWN; // default to down
+
+	if (_manual_control_sp.gear_switch == manual_control_setpoint_s::SWITCH_POS_ON && _gear_state_initialized) {
+		landing_gear = landing_gear_s::GEAR_UP;
+
+	} else if (_manual_control_sp.gear_switch == manual_control_setpoint_s::SWITCH_POS_OFF) {
+		// Switching the gear off does put it into a safe defined state
+		_gear_state_initialized = true;
+	}
+
+	return landing_gear;
+}
+
+void
+LTAAttitudeControl::publish_rates_setpoint()
+{
+	_v_rates_sp.roll = _rates_sp(0);
+	_v_rates_sp.pitch = -_rates_sp(1);
+	_v_rates_sp.yaw = _rates_sp(2);
+	_v_rates_sp.thrust_body[0] = 0.0f;
+	_v_rates_sp.thrust_body[1] = 0.0f;
+	_v_rates_sp.thrust_body[2] = -_thrust_sp;
+	_v_rates_sp.timestamp = hrt_absolute_time();
+
+	_v_rates_sp_pub.publish(_v_rates_sp);
+}
+
+void
+LTAAttitudeControl::publish_rate_controller_status()
+{
+	rate_ctrl_status_s rate_ctrl_status = {};
+	rate_ctrl_status.timestamp = hrt_absolute_time();
+	_controller_status_pub.publish(rate_ctrl_status);
+}
+
+void
+LTAAttitudeControl::publish_actuator_controls()
+{
+	_actuators.control[0] = 0.0f;
+	_actuators.control[1] = _manual_control_sp.x;
+	_actuators.control[2] = _manual_control_sp.r;
+	_actuators.control[3] = _manual_control_sp.z;
+	_actuators.control[7] = (float)_landing_gear.landing_gear;
+	// note: _actuators.timestamp_sample is set in LTAAttitudeControl::Run()
+	_actuators.timestamp = hrt_absolute_time();
+
+	/* scale effort by battery status */
+	if (_param_mc_bat_scale_en.get() && _battery_status.scale > 0.0f) {
+		for (int i = 0; i < 4; i++) {
+			_actuators.control[i] *= _battery_status.scale;
+		}
+	}
+
+	if (!_actuators_0_circuit_breaker_enabled) {
+		orb_publish_auto(_actuators_id, &_actuators_0_pub, &_actuators, nullptr, ORB_PRIO_DEFAULT);
+	}
+}
+
+void
+LTAAttitudeControl::Run()
+{
+	if (should_exit()) {
+		_vehicle_angular_velocity_sub.unregisterCallback();
+		exit_and_cleanup();
+		return;
+	}
+
+	perf_begin(_loop_perf);
+
+	/* run controller on gyro changes */
+	vehicle_angular_velocity_s angular_velocity;
+
+	if (_vehicle_angular_velocity_sub.update(&angular_velocity)) {
+		const hrt_abstime now = hrt_absolute_time();
+
+		// Guard against too small (< 0.2ms) and too large (> 20ms) dt's.
+		const float dt = math::constrain(((now - _last_run) / 1e6f), 0.0002f, 0.02f);
+		_last_run = now;
+
+		const Vector3f rates{angular_velocity.xyz};
+
+		_actuators.timestamp_sample = angular_velocity.timestamp_sample;
+
+		/* run the rate controller immediately after a gyro update */
+		if (_v_control_mode.flag_control_rates_enabled) {
+			publish_actuator_controls();
+			publish_rate_controller_status();
+		}
+
+		/* check for updates in other topics */
+		_v_control_mode_sub.update(&_v_control_mode);
+		_battery_status_sub.update(&_battery_status);
+		_vehicle_land_detected_sub.update(&_vehicle_land_detected);
+		_landing_gear_sub.update(&_landing_gear);
+		vehicle_status_poll();
+		vehicle_motor_limits_poll();
+		const bool manual_control_updated = _manual_control_sp_sub.update(&_manual_control_sp);
+		const bool attitude_updated = vehicle_attitude_poll();
+
+		_attitude_dt += dt;
+
+		bool attitude_setpoint_generated = _v_control_mode.flag_control_altitude_enabled || _v_control_mode.flag_control_velocity_enabled || _v_control_mode.flag_control_position_enabled;
+
+		if (attitude_setpoint_generated) {
+			if (attitude_updated) {
+
+				if (_v_control_mode.flag_control_yawrate_override_enabled) {
+					/* Yaw rate override enabled, overwrite the yaw setpoint */
+					_v_rates_sp_sub.update(&_v_rates_sp);
+					const auto yawrate_reference = _v_rates_sp.yaw;
+					_rates_sp(2) = yawrate_reference;
+				}
+
+				publish_rates_setpoint();
+			}
+		} else {
+			/* attitude controller disabled, poll rates setpoint topic */
+			if (_v_control_mode.flag_control_manual_enabled) {
+				if (manual_control_updated) {
+					/* manual control - feed RC commands to actuators directly */
+					_v_att_sp.thrust_body[0] = _manual_control_sp.x;
+					_v_att_sp.thrust_body[2] = _manual_control_sp.z;
+					_rates_sp(2) = _manual_control_sp.r;
+
+					// PX4_INFO("\nManual X: %.2f\nManual Z: %.2f\nManual R: %.2f\n",
+					// 	(double)_manual_control_sp.x, (double)_manual_control_sp.z,
+					// 	(double)_manual_control_sp.r);
+
+					publish_rates_setpoint();
+				}
+
+			} else {
+				/* attitude controller disabled, poll rates setpoint topic */
+				if (_v_rates_sp_sub.update(&_v_rates_sp)) {
+					_rates_sp(0) = _v_rates_sp.roll;
+					_rates_sp(1) = _v_rates_sp.pitch;
+					_rates_sp(2) = _v_rates_sp.yaw;
+					_thrust_sp = -_v_rates_sp.thrust_body[2];
+				}
+			}
+		}
+
+
+		if (_v_control_mode.flag_control_termination_enabled) {
+			if (!_vehicle_status.is_vtol) {
+				_rates_sp.zero();
+				_thrust_sp = 0.0f;
+				_att_control.zero();
+				publish_actuator_controls();
+			}
+		}
+
+		/* calculate loop update rate while disarmed or at least a few times (updating the filter is expensive) */
+		if (!_v_control_mode.flag_armed || (now - _task_start) < 3300000) {
+			_dt_accumulator += dt;
+			++_loop_counter;
+
+			if (_dt_accumulator > 1.f) {
+				const float loop_update_rate = (float)_loop_counter / _dt_accumulator;
+				_loop_update_rate_hz = _loop_update_rate_hz * 0.5f + loop_update_rate * 0.5f;
+				_dt_accumulator = 0;
+				_loop_counter = 0;
+			}
+		}
+
+		parameter_update_poll();
+	}
+
+	perf_end(_loop_perf);
+}
+
+int LTAAttitudeControl::task_spawn(int argc, char *argv[])
+{
+	LTAAttitudeControl *instance = new LTAAttitudeControl();
+
+	if (instance) {
+		_object.store(instance);
+		_task_id = task_id_is_work_queue;
+
+		if (instance->init()) {
+			return PX4_OK;
+		}
+
+	} else {
+		PX4_ERR("alloc failed");
+	}
+
+	delete instance;
+	_object.store(nullptr);
+	_task_id = -1;
+
+	return PX4_ERROR;
+}
+
+int LTAAttitudeControl::print_status()
+{
+	PX4_INFO("Running");
+
+	perf_print_counter(_loop_perf);
+
+	print_message(_actuators);
+
+	return 0;
+}
+
+int LTAAttitudeControl::custom_command(int argc, char *argv[])
+{
+	return print_usage("unknown command");
+}
+
+int LTAAttitudeControl::print_usage(const char *reason)
+{
+	if (reason) {
+		PX4_WARN("%s\n", reason);
+	}
+
+	PRINT_MODULE_DESCRIPTION(
+		R"DESCR_STR(
+### Description
+This implements the multicopter attitude and rate controller. It takes attitude
+setpoints (`vehicle_attitude_setpoint`) or rate setpoints (in acro mode
+via `manual_control_setpoint` topic) as inputs and outputs actuator control messages.
+
+The controller has two loops: a P loop for angular error and a PID loop for angular rate error.
+
+Publication documenting the implemented Quaternion Attitude Control:
+Nonlinear Quadrocopter Attitude Control (2013)
+by Dario Brescianini, Markus Hehn and Raffaello D'Andrea
+Institute for Dynamic Systems and Control (IDSC), ETH Zurich
+
+https://www.research-collection.ethz.ch/bitstream/handle/20.500.11850/154099/eth-7387-01.pdf
+
+### Implementation
+To reduce control latency, the module directly polls on the gyro topic published by the IMU driver.
+
+)DESCR_STR");
+
+	PRINT_MODULE_USAGE_NAME("lta_att_control", "controller");
+	PRINT_MODULE_USAGE_COMMAND("start");
+	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
+
+	return 0;
+}
+
+int lta_att_control_main(int argc, char *argv[])
+{
+	return LTAAttitudeControl::main(argc, argv);
+}

--- a/src/modules/lta_att_control/lta_att_control_params.c
+++ b/src/modules/lta_att_control/lta_att_control_params.c
@@ -1,0 +1,522 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2013-2015 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file lta_att_control_params.c
+ * Parameters for multicopter attitude controller.
+ *
+ * @author Lorenz Meier <lorenz@px4.io>
+ * @author Anton Babushkin <anton@px4.io>
+ * @author Daniel Robinson <daniel@flycloudline.com>
+ */
+
+/**
+ * Roll P gain
+ *
+ * Roll proportional gain, i.e. desired angular speed in rad/s for error 1 rad.
+ *
+ * @unit 1/s
+ * @min 0.0
+ * @max 12
+ * @decimal 2
+ * @increment 0.1
+ * @group Multicopter Attitude Control
+ */
+PARAM_DEFINE_FLOAT(LT_ROLL_P, 6.5f);
+
+/**
+ * Roll rate P gain
+ *
+ * Roll rate proportional gain, i.e. control output for angular speed error 1 rad/s.
+ *
+ * @min 0.0
+ * @max 0.5
+ * @decimal 3
+ * @increment 0.01
+ * @group Multicopter Attitude Control
+ */
+PARAM_DEFINE_FLOAT(LT_ROLLRATE_P, 0.15f);
+
+/**
+ * Roll rate I gain
+ *
+ * Roll rate integral gain. Can be set to compensate static thrust difference or gravity center offset.
+ *
+ * @min 0.0
+ * @decimal 3
+ * @increment 0.01
+ * @group Multicopter Attitude Control
+ */
+PARAM_DEFINE_FLOAT(LT_ROLLRATE_I, 0.2f);
+
+/**
+ * Roll rate integrator limit
+ *
+ * Roll rate integrator limit. Can be set to increase the amount of integrator available to counteract disturbances or reduced to improve settling time after large roll moment trim changes.
+ *
+ * @min 0.0
+ * @decimal 2
+ * @increment 0.01
+ * @group Multicopter Attitude Control
+ */
+PARAM_DEFINE_FLOAT(MC_RR_INT_LIM, 0.30f);
+
+/**
+ * Roll rate D gain
+ *
+ * Roll rate differential gain. Small values help reduce fast oscillations. If value is too big oscillations will appear again.
+ *
+ * @min 0.0
+ * @max 0.01
+ * @decimal 4
+ * @increment 0.0005
+ * @group Multicopter Attitude Control
+ */
+PARAM_DEFINE_FLOAT(LT_ROLLRATE_D, 0.003f);
+
+/**
+ * Roll rate feedforward
+ *
+ * Improves tracking performance.
+ *
+ * @min 0.0
+ * @decimal 4
+ * @group Multicopter Attitude Control
+ */
+PARAM_DEFINE_FLOAT(LT_ROLLRATE_FF, 0.0f);
+
+/**
+ * Roll rate controller gain
+ *
+ * Global gain of the controller.
+ *
+ * This gain scales the P, I and D terms of the controller:
+ * output = LT_ROLLRATE_K * (LT_ROLLRATE_P * error
+ * 			     + LT_ROLLRATE_I * error_integral
+ * 			     + LT_ROLLRATE_D * error_derivative)
+ * Set LT_ROLLRATE_P=1 to implement a PID in the ideal form.
+ * Set LT_ROLLRATE_K=1 to implement a PID in the parallel form.
+ *
+ * @min 0.0
+ * @max 5.0
+ * @decimal 4
+ * @increment 0.0005
+ * @group Multicopter Attitude Control
+ */
+PARAM_DEFINE_FLOAT(LT_ROLLRATE_K, 1.0f);
+
+/**
+ * Pitch P gain
+ *
+ * Pitch proportional gain, i.e. desired angular speed in rad/s for error 1 rad.
+ *
+ * @unit 1/s
+ * @min 0.0
+ * @max 12
+ * @decimal 2
+ * @increment 0.1
+ * @group Multicopter Attitude Control
+ */
+PARAM_DEFINE_FLOAT(LT_PITCH_P, 6.5f);
+
+/**
+ * Pitch rate P gain
+ *
+ * Pitch rate proportional gain, i.e. control output for angular speed error 1 rad/s.
+ *
+ * @min 0.0
+ * @max 0.6
+ * @decimal 3
+ * @increment 0.01
+ * @group Multicopter Attitude Control
+ */
+PARAM_DEFINE_FLOAT(LT_PITCHRATE_P, 0.15f);
+
+/**
+ * Pitch rate I gain
+ *
+ * Pitch rate integral gain. Can be set to compensate static thrust difference or gravity center offset.
+ *
+ * @min 0.0
+ * @decimal 3
+ * @increment 0.01
+ * @group Multicopter Attitude Control
+ */
+PARAM_DEFINE_FLOAT(LT_PITCHRATE_I, 0.2f);
+
+/**
+ * Pitch rate integrator limit
+ *
+ * Pitch rate integrator limit. Can be set to increase the amount of integrator available to counteract disturbances or reduced to improve settling time after large pitch moment trim changes.
+ *
+ * @min 0.0
+ * @decimal 2
+ * @increment 0.01
+ * @group Multicopter Attitude Control
+ */
+PARAM_DEFINE_FLOAT(MC_PR_INT_LIM, 0.30f);
+
+/**
+ * Pitch rate D gain
+ *
+ * Pitch rate differential gain. Small values help reduce fast oscillations. If value is too big oscillations will appear again.
+ *
+ * @min 0.0
+ * @decimal 4
+ * @increment 0.0005
+ * @group Multicopter Attitude Control
+ */
+PARAM_DEFINE_FLOAT(LT_PITCHRATE_D, 0.003f);
+
+/**
+ * Pitch rate feedforward
+ *
+ * Improves tracking performance.
+ *
+ * @min 0.0
+ * @decimal 4
+ * @group Multicopter Attitude Control
+ */
+PARAM_DEFINE_FLOAT(LT_PITCHRATE_FF, 0.0f);
+
+/**
+ * Pitch rate controller gain
+ *
+ * Global gain of the controller.
+ *
+ * This gain scales the P, I and D terms of the controller:
+ * output = LT_PITCHRATE_K * (LT_PITCHRATE_P * error
+ * 			     + LT_PITCHRATE_I * error_integral
+ * 			     + LT_PITCHRATE_D * error_derivative)
+ * Set LT_PITCHRATE_P=1 to implement a PID in the ideal form.
+ * Set LT_PITCHRATE_K=1 to implement a PID in the parallel form.
+ *
+ * @min 0.0
+ * @max 5.0
+ * @decimal 4
+ * @increment 0.0005
+ * @group Multicopter Attitude Control
+ */
+PARAM_DEFINE_FLOAT(LT_PITCHRATE_K, 1.0f);
+
+/**
+ * Yaw P gain
+ *
+ * Yaw proportional gain, i.e. desired angular speed in rad/s for error 1 rad.
+ *
+ * @unit 1/s
+ * @min 0.0
+ * @max 5
+ * @decimal 2
+ * @increment 0.1
+ * @group Multicopter Attitude Control
+ */
+PARAM_DEFINE_FLOAT(LT_YAW_P, 2.8f);
+
+/**
+ * Yaw rate P gain
+ *
+ * Yaw rate proportional gain, i.e. control output for angular speed error 1 rad/s.
+ *
+ * @min 0.0
+ * @max 0.6
+ * @decimal 2
+ * @increment 0.01
+ * @group Multicopter Attitude Control
+ */
+PARAM_DEFINE_FLOAT(LT_YAWRATE_P, 0.2f);
+
+/**
+ * Yaw rate I gain
+ *
+ * Yaw rate integral gain. Can be set to compensate static thrust difference or gravity center offset.
+ *
+ * @min 0.0
+ * @decimal 2
+ * @increment 0.01
+ * @group Multicopter Attitude Control
+ */
+PARAM_DEFINE_FLOAT(LT_YAWRATE_I, 0.1f);
+
+/**
+ * Yaw rate integrator limit
+ *
+ * Yaw rate integrator limit. Can be set to increase the amount of integrator available to counteract disturbances or reduced to improve settling time after large yaw moment trim changes.
+ *
+ * @min 0.0
+ * @decimal 2
+ * @increment 0.01
+ * @group Multicopter Attitude Control
+ */
+PARAM_DEFINE_FLOAT(MC_YR_INT_LIM, 0.30f);
+
+/**
+ * Yaw rate D gain
+ *
+ * Yaw rate differential gain. Small values help reduce fast oscillations. If value is too big oscillations will appear again.
+ *
+ * @min 0.0
+ * @decimal 2
+ * @increment 0.01
+ * @group Multicopter Attitude Control
+ */
+PARAM_DEFINE_FLOAT(LT_YAWRATE_D, 0.0f);
+
+/**
+ * Yaw rate feedforward
+ *
+ * Improves tracking performance.
+ *
+ * @min 0.0
+ * @decimal 4
+ * @increment 0.01
+ * @group Multicopter Attitude Control
+ */
+PARAM_DEFINE_FLOAT(LT_YAWRATE_FF, 0.0f);
+
+/**
+ * Yaw rate controller gain
+ *
+ * Global gain of the controller.
+ *
+ * This gain scales the P, I and D terms of the controller:
+ * output = LT_YAWRATE_K * (LT_YAWRATE_P * error
+ * 			     + LT_YAWRATE_I * error_integral
+ * 			     + LT_YAWRATE_D * error_derivative)
+ * Set LT_YAWRATE_P=1 to implement a PID in the ideal form.
+ * Set LT_YAWRATE_K=1 to implement a PID in the parallel form.
+ *
+ * @min 0.0
+ * @max 5.0
+ * @decimal 4
+ * @increment 0.0005
+ * @group Multicopter Attitude Control
+ */
+PARAM_DEFINE_FLOAT(LT_YAWRATE_K, 1.0f);
+
+/**
+ * Max roll rate
+ *
+ * Limit for roll rate in manual and auto modes (except acro).
+ * Has effect for large rotations in autonomous mode, to avoid large control
+ * output and mixer saturation.
+ *
+ * This is not only limited by the vehicle's properties, but also by the maximum
+ * measurement rate of the gyro.
+ *
+ * @unit deg/s
+ * @min 0.0
+ * @max 1800.0
+ * @decimal 1
+ * @increment 5
+ * @group Multicopter Attitude Control
+ */
+PARAM_DEFINE_FLOAT(LT_ROLLRATE_MAX, 220.0f);
+
+/**
+ * Max pitch rate
+ *
+ * Limit for pitch rate in manual and auto modes (except acro).
+ * Has effect for large rotations in autonomous mode, to avoid large control
+ * output and mixer saturation.
+ *
+ * This is not only limited by the vehicle's properties, but also by the maximum
+ * measurement rate of the gyro.
+ *
+ * @unit deg/s
+ * @min 0.0
+ * @max 1800.0
+ * @decimal 1
+ * @increment 5
+ * @group Multicopter Attitude Control
+ */
+PARAM_DEFINE_FLOAT(LT_PITCHRATE_MAX, 220.0f);
+
+/**
+ * Max yaw rate
+ *
+ * @unit deg/s
+ * @min 0.0
+ * @max 1800.0
+ * @decimal 1
+ * @increment 5
+ * @group Multicopter Attitude Control
+ */
+PARAM_DEFINE_FLOAT(LT_YAWRATE_MAX, 200.0f);
+
+/**
+ * Max acro roll rate
+ * default: 2 turns per second
+ *
+ * @unit deg/s
+ * @min 0.0
+ * @max 1800.0
+ * @decimal 1
+ * @increment 5
+ * @group Multicopter Attitude Control
+ */
+PARAM_DEFINE_FLOAT(MC_ACRO_R_MAX, 720.0f);
+
+/**
+ * Max acro pitch rate
+ * default: 2 turns per second
+ *
+ * @unit deg/s
+ * @min 0.0
+ * @max 1800.0
+ * @decimal 1
+ * @increment 5
+ * @group Multicopter Attitude Control
+ */
+PARAM_DEFINE_FLOAT(MC_ACRO_P_MAX, 720.0f);
+
+/**
+ * Max acro yaw rate
+ * default 1.5 turns per second
+ *
+ * @unit deg/s
+ * @min 0.0
+ * @max 1800.0
+ * @decimal 1
+ * @increment 5
+ * @group Multicopter Attitude Control
+ */
+PARAM_DEFINE_FLOAT(MC_ACRO_Y_MAX, 540.0f);
+
+/**
+ * Acro mode Expo factor for Roll and Pitch.
+ *
+ * Exponential factor for tuning the input curve shape.
+ *
+ * 0 Purely linear input curve
+ * 1 Purely cubic input curve
+ *
+ * @min 0
+ * @max 1
+ * @decimal 2
+ * @group Multicopter Attitude Control
+ */
+PARAM_DEFINE_FLOAT(MC_ACRO_EXPO, 0.69f);
+
+/**
+ * Acro mode Expo factor for Yaw.
+ *
+ * Exponential factor for tuning the input curve shape.
+ *
+ * 0 Purely linear input curve
+ * 1 Purely cubic input curve
+ *
+ * @min 0
+ * @max 1
+ * @decimal 2
+ * @group Multicopter Attitude Control
+ */
+PARAM_DEFINE_FLOAT(MC_ACRO_EXPO_Y, 0.69f);
+
+/**
+ * Acro mode SuperExpo factor for Roll and Pitch.
+ *
+ * SuperExpo factor for refining the input curve shape tuned using MC_ACRO_EXPO.
+ *
+ * 0 Pure Expo function
+ * 0.7 resonable shape enhancement for intuitive stick feel
+ * 0.95 very strong bent input curve only near maxima have effect
+ *
+ * @min 0
+ * @max 0.95
+ * @decimal 2
+ * @group Multicopter Attitude Control
+ */
+PARAM_DEFINE_FLOAT(MC_ACRO_SUPEXPO, 0.7f);
+
+/**
+ * Acro mode SuperExpo factor for Yaw.
+ *
+ * SuperExpo factor for refining the input curve shape tuned using MC_ACRO_EXPO_Y.
+ *
+ * 0 Pure Expo function
+ * 0.7 resonable shape enhancement for intuitive stick feel
+ * 0.95 very strong bent input curve only near maxima have effect
+ *
+ * @min 0
+ * @max 0.95
+ * @decimal 2
+ * @group Multicopter Attitude Control
+ */
+PARAM_DEFINE_FLOAT(MC_ACRO_SUPEXPOY, 0.7f);
+
+/**
+ * Threshold for Rattitude mode
+ *
+ * Manual input needed in order to override attitude control rate setpoints
+ * and instead pass manual stick inputs as rate setpoints
+ *
+ * @min 0.0
+ * @max 1.0
+ * @decimal 2
+ * @increment 0.01
+ * @group Multicopter Attitude Control
+ */
+PARAM_DEFINE_FLOAT(MC_RATT_TH, 0.8f);
+
+/**
+ * Battery power level scaler
+ *
+ * This compensates for voltage drop of the battery over time by attempting to
+ * normalize performance across the operating range of the battery. The copter
+ * should constantly behave as if it was fully charged with reduced max acceleration
+ * at lower battery percentages. i.e. if hover is at 0.5 throttle at 100% battery,
+ * it will still be 0.5 at 60% battery.
+ *
+ * @boolean
+ * @group Multicopter Attitude Control
+ */
+PARAM_DEFINE_INT32(MC_BAT_SCALE_EN, 0);
+
+/**
+ * Cutoff frequency for the low pass filter on the D-term in the rate controller
+ *
+ * The D-term uses the derivative of the rate and thus is the most susceptible to noise.
+ * Therefore, using a D-term filter allows to decrease the driver-level filtering, which
+ * leads to reduced control latency and permits to increase the P gains.
+ * A value of 0 disables the filter.
+ *
+ * @unit Hz
+ * @min 0
+ * @max 1000
+ * @decimal 0
+ * @increment 10
+ * @group Multicopter Attitude Control
+ */
+PARAM_DEFINE_FLOAT(MC_DTERM_CUTOFF, 0.f);
+


### PR DESCRIPTION
This new vehicle type addition to the PX4 developer community is an airship which can also be simulated in Gazebo. This update brings the cloudship airframe, mixer, manual flying and links to [https://github.com/flycloudline/sitl_gazebo_airship](https://github.com/flycloudline/sitl_gazebo_airship)